### PR TITLE
Remove excessive top margin in SearchBar

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -13,7 +13,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex justify-center w-full mt-20">
+    <form onSubmit={handleSubmit} className="flex justify-center w-full">
       <input
         type="text"
         value={query}


### PR DESCRIPTION
📌 **Summary:**
This pull request removes excessive top margin in SearchBar, which is causing misalignment in the Home page.

✅ **Modifications made:**
- Removed `mt-20` from the parent div

📎 **Related Issue:**
- Closes #12 